### PR TITLE
Fix "uninitialized string offset".

### DIFF
--- a/svg/svgtools.inc
+++ b/svg/svgtools.inc
@@ -177,7 +177,9 @@ function addChild(SimpleXMLElement $element, $featureColours, $chargeGroup, $cha
   if ($id != null && substr($id, 0, 4) != 'path' && substr($id, 0, 5) != 'group') {
     // We allow multiple features with numeric flags at the end
     $len = strlen($id);
-    if ($id[$len-2] == '-' && ctype_digit($id[$len-1])) $id = substr($id, 0, $len - 2);
+    if ($len >= 2 && $id[$len-2] == '-' && ctype_digit($id[$len-1])) {
+      $id = substr($id, 0, $len - 2);
+    }
     if (array_key_exists($id, $featureColours)) { // this is a feature with a given colour
       $class = "feature $id";
       $item .= ' fill="' . $featureColours[$id] . '" ';


### PR DESCRIPTION
svg/charges/emblem/star-of-david.svg includes a <path> element with id="t". This
short ID caused an "Uninitialized string offset" notice for the expression
$id[$len-2]. (The notice is perhaps easy to miss; it is printed to stderr and
should show up in server error logs.)

Tested:

Before:
$ php drawshield.php 'Argent, a star of David azure'
PHP Notice:  Uninitialized string offset: -1 in /home/brian/repos/Drawshield-Code/svg/svgtools.inc on line 180
<?xml version="1.0" encoding="utf-8" ?>
...

After:
$ php drawshield.php 'Argent, a star of David azure'
<?xml version="1.0" encoding="utf-8" ?>
...