### PR TITLE
Change bezant to look like other roundels.

### DIFF
--- a/svg/charges/geometric/bezant.inc
+++ b/svg/charges/geometric/bezant.inc
@@ -7,4 +7,4 @@ foreach ( $node->childNodes as $child ) {
   }
 }
 
-$charge['file'] = 'bezant.svg';
+$charge['file'] = 'roundel.svg';


### PR DESCRIPTION


The user guide indicates that a bezant is simply a roundel, like a golpe, guze,
hurt, and so on. This matches other sources, which describe a bezant as a
roundel or. So it is surprising if "bezant" is different from "roundel or". Most
illustrations including bezants also show them as flat discs, not as
three-dimensional representations of coins in perspective.

Tested:
$ php drawshield.php 'Azure, three bezants' | convert - out.png
![out](https://user-images.githubusercontent.com/62176468/77371380-71ffc980-6d63-11ea-852e-b79ad6114efd.png)
