### PR TITLE
Case-insensitivity for symbols.

### DIFF
--- a/svg/charges/alchemical/symbol.inc
+++ b/svg/charges/alchemical/symbol.inc
@@ -11,7 +11,7 @@
  * Time: 23:00
  */
 
-$item = getModifierValueByKeyterm($node,'value');
+$item = strtolower(getModifierValueByKeyterm($node,'value'));
 if ( file_exists( $folder . $item . '.svg'))
   $charge['file'] = "$item.svg";
 else {

--- a/svg/charges/astronomical/symbol.inc
+++ b/svg/charges/astronomical/symbol.inc
@@ -11,7 +11,7 @@
  * Time: 23:00
  */
 
-$planet = getModifierValueByKeyterm($node,'value');
+$planet = strtolower(getModifierValueByKeyterm($node,'value'));
 if ( file_exists( $folder . $planet . '.svg'))
   $charge['file'] = "$planet.svg";
 else {

--- a/svg/charges/characters/letter.inc
+++ b/svg/charges/characters/letter.inc
@@ -17,7 +17,12 @@
 $charge['default_colour'] = 'sable';
 $value = getModifierValueByKeyterm ( $node, 'value' );
 $font = getModifierValueByKeyterm ( $node, 'font' );
-if (is_null($font) || !file_exists($folder . "fonts/" . $font . '.svg')) $font = "gothic";
+if (is_null($font)) {
+  $font = 'gothic';
+} else {
+  $font = strtolower($font);
+  if (!file_exists($folder . 'fonts/' . $font . '.svg')) $font = 'gothic';
+}
 $glyphs = simplexml_load_file($folder . "fonts/" . $font . '.svg' );
 $numChars = strlen($value);
 // set vertical flex quite high?

--- a/svg/charges/symbol/any.inc
+++ b/svg/charges/symbol/any.inc
@@ -11,7 +11,7 @@
  * Time: 23:00
  */
 
-$item = getModifierValueByKeyterm($node,'value');
+$item = strtolower(getModifierValueByKeyterm($node,'value'));
 if ( file_exists( $folder . '../alchemical/' . $item . '.svg')) {
   $charge['file'] = "../alchemical/$item.svg";
 } elseif ( file_exists( $folder . '../astronomical/' . $item . '.svg')) {

--- a/svg/charges/zodiac/symbol.inc
+++ b/svg/charges/zodiac/symbol.inc
@@ -1,6 +1,6 @@
 <?php
 
-$item = getModifierValueByKeyterm($node,'value');
+$item = strtolower(getModifierValueByKeyterm($node,'value'));
 if ( file_exists( $folder . $item . '.svg'))
   $charge['file'] = "$item.svg";
 else {


### PR DESCRIPTION
For alchemical, astronomical, and zodiac symbols, and names of fonts, a token from the blazon is used as a file name. This doesn't work if the token is capitalised, because the file names are lower-case. Case-insensitivity is especially important for astronomical and zodiac symbols, because the names there (e.g., Saturn, Capricorn) are properly written with an initial capital letter.

# Test blazons

## (alchemical/symbol) Argent, an alchemical symbol for Air sable

Before: WARNING No symbol for Air (using fire)
![Argent, an alchemical symbol for Air sable](https://user-images.githubusercontent.com/62176468/77468824-72a16a00-6e0e-11ea-9001-02426eb913d8.png)

After:
![Argent, an alchemical symbol for Air sable](https://user-images.githubusercontent.com/62176468/77468954-a41a3580-6e0e-11ea-8972-cf26e11245b8.png)

## (astronomical/symbol) Argent, an astronomical symbol for Venus sable

Before: WARNING No symbol for Venus (using sun)
![Argent, an astronomical symbol for Venus sable](https://user-images.githubusercontent.com/62176468/77469254-1559e880-6e0f-11ea-8eae-693f77821c03.png)

After:
![Argent, an astronomical symbol for Venus sable](https://user-images.githubusercontent.com/62176468/77469341-34f11100-6e0f-11ea-954a-64372fb85539.png)

## (characters/letter) Argent, the letter K in a Script font sable

Before (note that this is the Gothic font):
![Argent, the letter K in a Script font sable](https://user-images.githubusercontent.com/62176468/77469420-55b96680-6e0f-11ea-979c-fca868fe4efd.png)

After:
![Argent, the letter K in a Script font sable](https://user-images.githubusercontent.com/62176468/77469496-75e92580-6e0f-11ea-8e63-a4c36f6793fa.png)

## (symbol/any) Argent, a symbol for Water sable

Before: WARNING No symbol for Water (using fire)
![Argent, a symbol for Water sable](https://user-images.githubusercontent.com/62176468/77469628-ab8e0e80-6e0f-11ea-8765-49be3d82c3a9.png)

After:
![Argent, a symbol for Water sable](https://user-images.githubusercontent.com/62176468/77469688-c2346580-6e0f-11ea-95d0-3dedee586ae2.png)

## (symbol/any) Argent, a symbol for Jupiter sable

Before: WARNING No symbol for Jupiter (using fire)
![Argent, a symbol for Jupiter sable](https://user-images.githubusercontent.com/62176468/77469782-e7c16f00-6e0f-11ea-94b9-a566f82d4d69.png)

After:
![Argent, a symbol for Jupiter sable](https://user-images.githubusercontent.com/62176468/77469846-fe67c600-6e0f-11ea-9f9c-b74dec2f7794.png)

## (zodiac/symbol) Argent, a zodiac symbol for Leo sable

Before: WARNING No symbol for Leo (using aries)
![Argent, a zodiac symbol for Leo sable](https://user-images.githubusercontent.com/62176468/77469924-20f9df00-6e10-11ea-851d-5e7fedc4460f.png)

After:
![Argent, a zodiac symbol for Leo sable](https://user-images.githubusercontent.com/62176468/77469966-340caf00-6e10-11ea-8e38-dad1c9140372.png)