### PR TITLE
Support zodiac symbols via symbol/any.

### DIFF
--- a/svg/charges/symbol/any.inc
+++ b/svg/charges/symbol/any.inc
@@ -16,6 +16,8 @@ if ( file_exists( $folder . '../alchemical/' . $item . '.svg')) {
   $charge['file'] = "../alchemical/$item.svg";
 } elseif ( file_exists( $folder . '../astronomical/' . $item . '.svg')) {
   $charge['file'] = "../astronomical/$item.svg";
+} elseif ( file_exists( $folder . '../zodiac/' . $item . '.svg')) {
+  $charge['file'] = "../zodiac/$item.svg";
 } else {
   $charge['file'] = "../alchemical/fire.svg";
   $messages->addMessage('warning',"No symbol for $item (using fire)");


### PR DESCRIPTION
This allows zodiac symbols to be referenced without the word "zodiac", like alchemical and astronomical symbols already can.

Tested:
Argent, a symbol for pisces sable

Before: WARNING No symbol for pisces (using fire)
![Argent, a symbol for pisces sable](https://user-images.githubusercontent.com/62176468/77472996-0fff9c80-6e15-11ea-8390-ce1840861ac6.png)

After:
![Argent, a symbol for pisces sable](https://user-images.githubusercontent.com/62176468/77473229-6b318f00-6e15-11ea-88e7-1fb61abe231b.png)