### PR TITLE
Fix treatments on inverted objects.

### DIFF
--- a/svg/tinctures.inc
+++ b/svg/tinctures.inc
@@ -193,7 +193,7 @@ function apply_tincture ($tinctureNode, $targetSVG, $chg_size = '',
         $treat_data = makeTreatment( $tinctureTypeNode );
         // If what we are placing is inverted, we also invert the fill so it appears the "right way up"
         // Don't need to do reversed as all treatments are symmetrical
-        if ( $inv ) $treat_data['width'] = "<g transform=\"translate(0,{$treat_data['height']}) scale(1,-1)\">{$treat_data['body']}</g>";
+        if ( $inv ) $treat_data['body'] = "<g transform=\"translate(0,{$treat_data['height']}) scale(1,-1)\">{$treat_data['body']}</g>";
         $patt_id = add_def ( 'pattern ' . $patTrans .
           ' patternContentUnits="userSpaceOnUse" patternUnits="userSpaceOnUse" x="0" y="0" width="' .
           $treat_data['width'] . '" height="' . $treat_data['height'] . '"',


### PR DESCRIPTION
Because of a typo, the previous code tried to put a bunch of SVG into a `width` attribute.

Test blazon: Argent, a chevron inverted chequy azure and or.
![Argent, a chevron inverted chequy azure and or](https://user-images.githubusercontent.com/62176468/77579468-ab0e7a00-6eda-11ea-9e53-b86503e863bb.png)
