### PR TITLE
Fix furs on inverted objects.

### DIFF
--- a/svg/tinctures.inc
+++ b/svg/tinctures.inc
@@ -176,7 +176,7 @@ function apply_tincture ($tinctureNode, $targetSVG, $chg_size = '',
       $fur_data = makeFur( $fur_name );
       // If what we are placing is inverted, we also invert the fill so it appears the "right way up"
       // Don't need to do reversed as all furs are symmetrical
-      if ( $inv ) $fur_data['body'] = "<g transform=\"translate(0,{$fur_data[1]}) scale(1,-1)\">{$fur_data['body']}</g>";
+      if ( $inv ) $fur_data['body'] = "<g transform=\"translate(0,{$fur_data['height']}) scale(1,-1)\">{$fur_data['body']}</g>";
       $patt_id = add_def ( 'pattern ' . $patTrans .
          ' patternContentUnits="userSpaceOnUse" patternUnits="userSpaceOnUse" x="0" y="0" width="' .
          $fur_data['width'] . '" height="' . $fur_data['height'] . '"',


### PR DESCRIPTION
The previous code attempted to access an array element by numeric index, when it's actually an associative array. This caused a warning from PHP and a malformed `translate` transform in the SVG.

Test blazon: Argent, a chevron inverted pean.

Before: The expression `$fur_data[1]` caused the following notice from PHP:

    PHP Notice:  Undefined offset: 1 in /home/brian/repos/Drawshield-Code/svg/tinctures.inc on line 179

And the output SVG contained the following:

    <g transform="translate(0,) scale(1,-1)">

Note the malformed `translate` here. The result was that either the ermine spots were upside-down or the fur was not drawn at all, depending on the SVG renderer. Example:
![Argent, a chevron inverted pean](https://user-images.githubusercontent.com/62176468/77761441-57b23e00-7038-11ea-8efb-e9a43362bf3f.png)

After: The shield is drawn correctly, with the ermine spots upright.
![Argent, a chevron inverted pean](https://user-images.githubusercontent.com/62176468/77761513-7adced80-7038-11ea-8a62-0f3140bd19e8.png)