### PR TITLE
Add "monk" to the parser.

### DIFF
--- a/parser/english/charge.inc
+++ b/parser/english/charge.inc
@@ -113,6 +113,7 @@
       array ( 'askers?', 'human/asker' ),
       array ( 'locks? of ?* hair', 'human/hair' ),
       array ( '?(hu)?mans? beards?', 'human/beard' ),
+      array ( 'monks?', 'human/monk' ),
       // ship
       array ( 'lymphads?', 'ship/galley' ),
       array ( 'oars?', 'ship/oars' ),


### PR DESCRIPTION
The visual catalog (https://drawshield.net/catalog/charges/human/index.html) lists "monk" as a charge, and the SVG exists; it was just missing from the parser.

As a resident of Munich, it is personally important to me to support blazons that include monks.

Test blazon: Argent, a monk sable.
![Argent, a monk sable](https://user-images.githubusercontent.com/62176468/78190329-15dc2a00-7474-11ea-9d82-34c429605098.png)