### PR TITLE
Fix "d'or", "d'eau", "d'huile", and "d'olive".

### DIFF
--- a/parser/english/lexicon.inc
+++ b/parser/english/lexicon.inc
@@ -357,13 +357,17 @@ class languageDB extends lexicon {
           'orange',
           // "de" names (for gouttes particularly)
           array ( 'd or', 'or'  ),
+          array ( 'dor', 'or' ),
           array ( 'd eau', 'argent'  ),
+          array ( 'deau', 'argent' ),
           array ( 'de larmes', 'azure'  ),
           array ( 'de sangu?e?', 'gules' ),
           array ( 'de vin', 'gules'   ),
           array ( 'de poix', 'sable'  ),
           array ( 'd huile',  'vert' ),
+          array ( 'dhuile', 'vert' ),
           array ( 'd olive',  'vert' ),
+          array ( 'dolive', 'vert' ),
           // obsolete names
           /* Start Comment obsolete names
            'amethyst', 'diamond', 'dragons head', 'dragons tail', 'emerald',


### PR DESCRIPTION
Commit ef284f78582d16f8d89aef17a363443f19d733c5 fixed the handling of apostrophes in phrases such as "horse's head". Unfortunately it broke the handling of these tinctures for gouttes.

Test blazons:

Sable, three gouttes d'or.
![Sable, three gouttes d'or](https://user-images.githubusercontent.com/62176468/78192327-2f7f7080-7478-11ea-986b-f26518c49b4f.png)

Sable, three gouttes d'eau.
![Sable, three gouttes d'eau](https://user-images.githubusercontent.com/62176468/78192372-4e7e0280-7478-11ea-85ac-f3fae387c341.png)

Argent, three gouttes d'huile.
![Argent, three gouttes d'huile](https://user-images.githubusercontent.com/62176468/78192422-66ee1d00-7478-11ea-938f-7df405edacd9.png)

Argent, three gouttes d'olive.
![Argent, three gouttes d'olive](https://user-images.githubusercontent.com/62176468/78192465-81c09180-7478-11ea-9929-cef53f777eee.png)