### PR TITLE
Tweaks to "Saint Florian cross".

### DIFF
--- a/parser/english/charge.inc
+++ b/parser/english/charge.inc
@@ -63,7 +63,7 @@
    $this->patterns[languageDB::CHARGE] = array (
       // cross
       array ( 'calvary cross(es)?', 'cross/calvary' ),
-      array ( '?(saint|st) florian cross(es)?', 'cross/calvary' ),
+      array ( '?(saint|st) florians? cross(es)?', 'quadrate/cross-florian' ),
       array ( 'greek cross(es)?', 'cross/greek' ),
       array ( 'coptic cross(es)?', 'quadrate/cross-coptic' ),
       array ( 'couped cross(es)?', 'cross/couped' ),


### PR DESCRIPTION
This change adds support for the phrasing "Saint Florian's cross" and fixes the charge.

Test blazons:
Argent, a Saint Florian cross gules.
Argent, a Saint Florian's cross gules.
![Argent, a Saint Florian cross gules](https://user-images.githubusercontent.com/62176468/78303462-f957f480-753c-11ea-825e-36e4e55a079e.png)
