### PR TITLE
Fix "Chinese dragon in annulo" and "serpent in annulo".

### DIFF
--- a/svg/charges/dragon/chinese-dragon.inc
+++ b/svg/charges/dragon/chinese-dragon.inc
@@ -1,0 +1,5 @@
+<?php
+
+if (existModifierWithKeyTerm($node, 'inannulo', true)) {
+    $charge['file'] = 'chinese-dragon-in-annulo.svg';
+}

--- a/svg/charges/serpent/serpent.inc
+++ b/svg/charges/serpent/serpent.inc
@@ -1,0 +1,5 @@
+<?php
+
+if (existModifierWithKeyTerm($node, 'inannulo', true)) {
+    $charge['file'] = 'serpent-in-annulo.svg';
+}


### PR DESCRIPTION
Following commit 3be81f7c23b5277d1c305e4d6d53f91aa61797e2, which fixed "dragon in annulo", this change takes the same approach to fix these two charges.

Test blazons:

Argent, a Chinese dragon in annulo gules.
![Argent, a Chinese dragon in annulo gules](https://user-images.githubusercontent.com/62176468/78398675-cae92080-75f3-11ea-8634-2e9895c03f28.png)

Argent, a serpent in annulo vert.
![Argent, a serpent in annulo vert](https://user-images.githubusercontent.com/62176468/78398727-e18f7780-75f3-11ea-9ee3-0d7b745b18d3.png)