### PR TITLE
Fix Heneage knot.

### DIFF
--- a/parser/english/charge.inc
+++ b/parser/english/charge.inc
@@ -1099,7 +1099,7 @@
       array ( 'knots?', 'knot/knot' ),
       array ( 'bourchier knots?', 'knot/bourchier' ),
       array ( 'harrington knots?', 'knot/harrington' ),
-      array ( 'he?ane?age knots?', 'knot/heneage-knot' ),
+      array ( 'hea?ne?age knots?', 'knot/heneage-knot' ),
       array ( 'ormonde knots?', 'knot/ormonde' ),
       array ( 'stafford knots?', 'knot/stafford-knot' ),
       array ( '(wake|ormond) knots?', 'knot/wake-knot' ),


### PR DESCRIPTION
The previous regex accepted the spellings "Hanage", "Haneage", "Heanage", and "Heaneage", but not the correct spelling "Heneage". Google returns no results for the quoted phrases "hanage knot" and "haneage knot", so it seems likely that the original intent was to support the spellings "Heanage", "Heaneage", "Henage", and "Heneage".

Test blazon: Argent, a Heneage knot sable.
![Argent, a Heneage knot sable](https://user-images.githubusercontent.com/62176468/78400311-b9edde80-75f6-11ea-85c0-307bf22d47e0.png)