### PR TITLE
Fix "{fess,dance} couped {dexter,sinister}".

### DIFF
--- a/svg/ordinaries/fess.inc
+++ b/svg/ordinaries/fess.inc
@@ -19,10 +19,10 @@ if ( existModifierWithKeyterm($node,'couped') ) {
   $ordinary['shape_spec'] = 'X100Y{%35}A800c{%30}E800g{%30}';
 }
 elseif ( existModifierWithKeyterm($node, 'couped-dexter')) {
-  $ordinary['shape_spec'] = 'X-8Y{%35}A908c{%30}E908g{%30}';
+  $ordinary['shape_spec'] = 'X100Y{%35}A908c{%30}E908g{%30}';
 }
 elseif ( existModifierWithKeyterm($node,'couped-sinister')) {
-  $ordinary['shape_spec'] = 'X100Y{%35}A908c{%30}E908g{%30}';
+  $ordinary['shape_spec'] = 'X-8Y{%35}A908c{%30}E908g{%30}';
 } elseif ( existModifierWithKeyterm($node,'fracted') ) {
   $ordinary['shape_spec'] = 'X-100Y{%50}A600g{%15}A600c{%15}E600c{%15}E600g{%15}';
 } elseif ( existModifierWithKeyterm($node,'lozengy')) {


### PR DESCRIPTION
These were backward, couped on the wrong side.

Test blazons:

Argent, a fess couped dexter azure.
![Argent, a fess couped dexter azure](https://user-images.githubusercontent.com/62176468/78596094-76d87900-784b-11ea-9483-90ae38dc60b6.png)

Argent, a fess couped sinister azure.
![Argent, a fess couped sinister azure](https://user-images.githubusercontent.com/62176468/78596174-98396500-784b-11ea-9af1-8840565f5aea.png)

Argent, a dance couped dexter azure.
![Argent, a dance couped dexter azure](https://user-images.githubusercontent.com/62176468/78596239-b69f6080-784b-11ea-928b-ec0ad428d695.png)

Argent, a dance couped sinister azure.
![Argent, a dance couped sinister azure](https://user-images.githubusercontent.com/62176468/78596276-c7e86d00-784b-11ea-8a74-54e347e2219b.png)