### PR TITLE
Fix colouring of "hurst".

### DIFF
--- a/svg/charges/natural/forest.svg
+++ b/svg/charges/natural/forest.svg
@@ -73,7 +73,7 @@
      style="display:inline"
      id="layer4">
     <g
-       style="display:inline;fill:#5ab532;fill-opacity:1;stroke:#000000;stroke-width:0.8424961;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="display:inline;fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:0.8424961;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        transform="matrix(2.3735718,0,0,2.3742245,-87.82162,-193.1712)"
        id="g43050">
       <g


### PR DESCRIPTION
Previously the fill in the SVG was not one of the magic colours, so it was not replaced by the tincture in the blazon.

Test blazon: Argent, a hurst azure.
![Argent, a hurst azure](https://user-images.githubusercontent.com/62176468/78937860-780adf80-7ab1-11ea-8a20-6cb221c98c03.png)